### PR TITLE
feat: add equipment access zones

### DIFF
--- a/apps/web/src/components/editor/components/ForbiddenZones.tsx
+++ b/apps/web/src/components/editor/components/ForbiddenZones.tsx
@@ -12,7 +12,7 @@ interface Props {
   mm2px: number;
 }
 
-export const DoorZones: React.FC<Props> = ({ zones, baseX, baseY, mm2px }) => (
+export const ForbiddenZones: React.FC<Props> = ({ zones, baseX, baseY, mm2px }) => (
   <>
     {zones.map(({ id, z }) => (
       <Rect

--- a/apps/web/src/components/editor/components/StaticObjectShape.tsx
+++ b/apps/web/src/components/editor/components/StaticObjectShape.tsx
@@ -22,7 +22,7 @@ interface Props {
   onTransformEnd: () => void;
   setRef: (ref: any) => void;
   zoom: number;
-  doorZones: { z: { X: number; Y: number; W: number; H: number } }[];
+  forbiddenZones: { z: { X: number; Y: number; W: number; H: number } }[];
 }
 
 export const StaticObjectShape: React.FC<Props> = ({
@@ -40,7 +40,7 @@ export const StaticObjectShape: React.FC<Props> = ({
   onTransformEnd,
   setRef,
   zoom,
-  doorZones,
+  forbiddenZones,
 }) => {
   const x = baseX + object.rect.X * mm2px;
   const y = baseY + object.rect.Y * mm2px;
@@ -90,7 +90,7 @@ export const StaticObjectShape: React.FC<Props> = ({
             W: object.rect.W,
             H: object.rect.H,
           };
-          const hit = doorZones.some(({ z }) => rIntersects(rect, z));
+          const hit = forbiddenZones.some(({ z }) => rIntersects(rect, z));
           if (hit) return last.current;
           last.current = { x: nx, y: ny };
           return { x: nx, y: ny };

--- a/apps/web/src/components/editor/components/index.ts
+++ b/apps/web/src/components/editor/components/index.ts
@@ -1,6 +1,6 @@
 export { Grid } from './Grid';
 export { Room } from './Room';
-export { DoorZones } from './DoorZones';
+export { ForbiddenZones } from './ForbiddenZones';
 export { StaticObjectShape } from './StaticObjectShape';
 export { PlacementGhost } from './PlacementGhost';
 export { MeasurementOverlay } from './MeasurementOverlay';

--- a/apps/web/src/components/editor/doorZone.ts
+++ b/apps/web/src/components/editor/doorZone.ts
@@ -1,4 +1,5 @@
 export const DOOR_CLEAR_FACTOR = 1.5; // квадрат со стороной 1.5*W двери, направлен внутрь
+export const EQUIP_CLEAR_DEPTH = 1000; // свободная зона перед оборудованием (мм)
 
 // пересечение прямоугольников (мм)
 export const rIntersects = (
@@ -53,5 +54,19 @@ export const computeDoorZone = (
       H: Math.min(side, room.H - H),
     };
   }
+  return null;
+};
+
+// зона свободного доступа для оборудования, примыкающего к стене
+export const computeEquipmentZone = (
+  room: { W: number; H: number },
+  rect: { X: number; Y: number; W: number; H: number }
+) => {
+  const { X, Y, W, H } = rect;
+  const d = EQUIP_CLEAR_DEPTH;
+  if (Y === 0) return { X, Y: Y + H, W, H: d }; // верхняя стена → вниз
+  if (Y + H === room.H) return { X, Y: Y - d, W, H: d }; // нижняя стена → вверх
+  if (X === 0) return { X: X + W, Y, W: d, H }; // левая стена → вправо
+  if (X + W === room.W) return { X: X - d, Y, W: d, H }; // правая стена → влево
   return null;
 };

--- a/apps/web/src/components/editor/hooks.ts
+++ b/apps/web/src/components/editor/hooks.ts
@@ -4,7 +4,7 @@ import { usePlanStore } from '../../store/planStore';
 
 export type View = { zoom: number; panX: number; panY: number };
 
-export const useContainerSize = (ref: React.RefObject<HTMLDivElement>) => {
+export const useContainerSize = (ref: React.RefObject<HTMLDivElement | null>) => {
   const [size, setSize] = React.useState({ w: 800, h: 600 });
   React.useLayoutEffect(() => {
     const el = ref.current;

--- a/apps/web/src/hooks/useContainerSize.ts
+++ b/apps/web/src/hooks/useContainerSize.ts
@@ -1,7 +1,7 @@
 'use client';
 import React from 'react';
 
-export const useContainerSize = (ref: React.RefObject<HTMLDivElement>) => {
+export const useContainerSize = (ref: React.RefObject<HTMLDivElement | null>) => {
   const [size, setSize] = React.useState({ w: 800, h: 600 });
   React.useLayoutEffect(() => {
     const el = ref.current;

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "jsx": "preserve",
     "moduleResolution": "Bundler",
+    "module": "esnext",
     "lib": [
       "dom",
       "dom.iterable",


### PR DESCRIPTION
## Summary
- block objects from overlapping equipment access zones
- render combined door and equipment clear areas on the canvas
- flag obstructions with new EQUIPMENT_ACCESS_CONFLICT rule

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build:packages`
- `npm -w @planner/web run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4225bd7a8832d82c7974b5988ae5e