### PR TITLE
feat: add configurable comms block radius

### DIFF
--- a/apps/web/src/components/EditorCanvas.tsx
+++ b/apps/web/src/components/EditorCanvas.tsx
@@ -21,6 +21,7 @@ import {
   StaticObjectShape,
   PlacementGhost,
   MeasurementOverlay,
+  CommsRadius,
 } from './editor/components';
 
 
@@ -229,7 +230,13 @@ export const EditorCanvas: React.FC = () => {
       id,
       type: placingType as StaticObject['type'],
       rect: { ...ghost },
-      properties: [],
+      properties:
+        placingType === 'comms_block'
+          ? [
+              { kind: 'capacity', value: 8 },
+              { kind: 'radius', value: 5000 },
+            ]
+          : [],
       requiresWallAnchor: REQUIRES_WALL.has(placingType),
     };
     addObject(obj);
@@ -413,20 +420,26 @@ export const EditorCanvas: React.FC = () => {
         }}
       >
         <Layer>
-          <Grid
-            baseX={baseX}
-            baseY={baseY}
-            room={plan.room}
-            mm2px={mm2px}
-            grid={GRID_MM}
-          />
-          <Room baseX={baseX} baseY={baseY} roomWpx={roomWpx} roomHpx={roomHpx} />
-          <ForbiddenZones zones={forbiddenZonesMm} baseX={baseX} baseY={baseY} mm2px={mm2px} />
+            <Grid
+              baseX={baseX}
+              baseY={baseY}
+              room={plan.room}
+              mm2px={mm2px}
+              grid={GRID_MM}
+            />
+            <Room baseX={baseX} baseY={baseY} roomWpx={roomWpx} roomHpx={roomHpx} />
+            <ForbiddenZones zones={forbiddenZonesMm} baseX={baseX} baseY={baseY} mm2px={mm2px} />
+            <CommsRadius
+              objects={plan.objects.filter(o => o.type === 'comms_block')}
+              baseX={baseX}
+              baseY={baseY}
+              mm2px={mm2px}
+            />
 
-          {plan.objects.map((o) => (
-            <StaticObjectShape
-              key={o.id}
-              object={o}
+            {plan.objects.map((o) => (
+              <StaticObjectShape
+                key={o.id}
+                object={o}
               selected={selectedId === o.id}
               baseX={baseX}
               baseY={baseY}

--- a/apps/web/src/components/ObjectList.tsx
+++ b/apps/web/src/components/ObjectList.tsx
@@ -37,7 +37,7 @@ const TYPE_COLOR: Record<string, { fill: string; stroke: string }> = {
 const fmtM2 = (mm2: number) => (mm2 / 1_000_000).toFixed(2); // м² из мм²
 
 export const ObjectList: React.FC = () => {
-  const { plan, selectedId, setSelected, deleteObject } = usePlanStore();
+  const { plan, selectedId, setSelected, deleteObject, setProperty } = usePlanStore();
   const [q, setQ] = React.useState('');
 
   const rows = React.useMemo(() => {
@@ -100,6 +100,8 @@ export const ObjectList: React.FC = () => {
               <th style={th}>Y (мм)</th>
               <th style={th}>W (мм)</th>
               <th style={th}>H (мм)</th>
+              <th style={th}>R (мм)</th>
+              <th style={th}>Емк.</th>
               <th style={th}>Площадь (м²)</th>
               <th style={th}>Нужна привязка</th>
               <th style={th}>На стене</th>
@@ -111,6 +113,8 @@ export const ObjectList: React.FC = () => {
               const color = TYPE_COLOR[o.type]?.stroke ?? '#6b7280';
               const onWall = isOnWall(o.rect, plan.room);
               const sel = selectedId === o.id;
+              const radius = o.properties.find(p => p.kind === 'radius')?.value ?? 0;
+              const capacity = o.properties.find(p => p.kind === 'capacity')?.value ?? 0;
               return (
                 <tr
                   key={o.id}
@@ -134,6 +138,26 @@ export const ObjectList: React.FC = () => {
                   <td style={tdNum}>{o.rect.Y}</td>
                   <td style={tdNum}>{o.rect.W}</td>
                   <td style={tdNum}>{o.rect.H}</td>
+                  <td style={tdNum}>
+                    {o.type === 'comms_block' && (
+                      <input
+                        type="number"
+                        value={radius}
+                        onChange={e => setProperty(o.id, { kind: 'radius', value: Number(e.target.value) })}
+                        style={{ width: 60, padding: '2px 4px', border: '1px solid #ddd', borderRadius: 4 }}
+                      />
+                    )}
+                  </td>
+                  <td style={tdNum}>
+                    {o.type === 'comms_block' && (
+                      <input
+                        type="number"
+                        value={capacity}
+                        onChange={e => setProperty(o.id, { kind: 'capacity', value: Number(e.target.value) })}
+                        style={{ width: 40, padding: '2px 4px', border: '1px solid #ddd', borderRadius: 4 }}
+                      />
+                    )}
+                  </td>
                   <td style={tdNum}>{fmtM2(o.rect.W * o.rect.H)}</td>
                   <td style={td}>{o.requiresWallAnchor ? 'Да' : 'Нет'}</td>
                   <td style={{ ...td, color: onWall ? '#16a34a' : '#ef4444' }}>{onWall ? 'Да' : 'Нет'}</td>
@@ -163,7 +187,7 @@ export const ObjectList: React.FC = () => {
               );
             })}
             {!rows.length && (
-              <tr><td colSpan={10} style={{ padding: 12, color: '#6b7280' }}>Ничего не найдено…</td></tr>
+              <tr><td colSpan={12} style={{ padding: 12, color: '#6b7280' }}>Ничего не найдено…</td></tr>
             )}
           </tbody>
         </table>

--- a/apps/web/src/components/editor/components/CommsRadius.tsx
+++ b/apps/web/src/components/editor/components/CommsRadius.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { Circle } from 'react-konva';
+import type { StaticObject } from '@planner/shared';
+
+interface Props {
+  objects: StaticObject[];
+  baseX: number;
+  baseY: number;
+  mm2px: number;
+}
+
+export const CommsRadius: React.FC<Props> = ({ objects, baseX, baseY, mm2px }) => (
+  <>
+    {objects.map(o => {
+      const r = o.properties.find(p => p.kind === 'radius');
+      if (!r) return null;
+      const cx = baseX + (o.rect.X + o.rect.W / 2) * mm2px;
+      const cy = baseY + (o.rect.Y + o.rect.H / 2) * mm2px;
+      return (
+        <Circle
+          key={'rad_' + o.id}
+          x={cx}
+          y={cy}
+          radius={r.value * mm2px}
+          stroke="#e879f9"
+          dash={[4, 4]}
+          listening={false}
+        />
+      );
+    })}
+  </>
+);

--- a/apps/web/src/components/editor/components/index.ts
+++ b/apps/web/src/components/editor/components/index.ts
@@ -4,3 +4,4 @@ export { ForbiddenZones } from './ForbiddenZones';
 export { StaticObjectShape } from './StaticObjectShape';
 export { PlacementGhost } from './PlacementGhost';
 export { MeasurementOverlay } from './MeasurementOverlay';
+export { CommsRadius } from './CommsRadius';

--- a/apps/web/src/store/planStore.ts
+++ b/apps/web/src/store/planStore.ts
@@ -1,6 +1,6 @@
 'use client';
 import { create } from 'zustand';
-import type { Plan, StaticObject, Issue, Size } from '@planner/shared';
+import type { Plan, StaticObject, Issue, Size, Property } from '@planner/shared';
 
 // аббревиатуры для id
 const TYPE_ABBR: Record<string, string> = {
@@ -28,6 +28,7 @@ type State = {
 
   updateObject: (id: string, patch: Partial<StaticObject['rect']>) => void;
   updateRoom: (patch: Partial<Size>) => void;
+  setProperty: (id: string, prop: Property) => void;
 
   // создание / удаление
   addObject: (o: StaticObject) => void;
@@ -85,6 +86,17 @@ export const usePlanStore = create<State>((set, get) => ({
   })),
 
   updateRoom: (patch) => set(s => ({ plan: { ...s.plan, room: { ...s.plan.room, ...patch } } })),
+
+  setProperty: (id, prop) => set(s => ({
+    plan: {
+      ...s.plan,
+      objects: s.plan.objects.map(o =>
+        o.id === id
+          ? { ...o, properties: [...o.properties.filter(p => p.kind !== prop.kind), prop] }
+          : o
+      ),
+    },
+  })),
 
   // последовательные id вида "<abbr>-<n>"
   nextIdForType: (type: string) => {

--- a/packages/serializer/src/toProlog.ts
+++ b/packages/serializer/src/toProlog.ts
@@ -3,6 +3,7 @@ import type { Plan, StaticObject } from '@planner/shared';
 
 const propToProlog = (p: StaticObject['properties'][number]): string => {
   if (p.kind === 'capacity') return `capacity(${p.value})`;
+  if (p.kind === 'radius') return `radius(${p.value})`;
   if (p.kind === 'status') return `status(${p.value})`;
   if (p.kind === 'type') return `type(${p.value})`;
   return '';

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -11,6 +11,7 @@ export interface Rect { X: Mm; Y: Mm; W: Mm; H: Mm }
 
 export type Property =
   | { kind: 'capacity'; value: number }
+  | { kind: 'radius'; value: Mm }
   | { kind: 'status'; value: 'evacuation' }
   | { kind: 'type'; value: string };
 


### PR DESCRIPTION
## Summary
- add radius property to shared types and serializer
- allow editing comms block radius and capacity in object list
- visualize comms block coverage circle on plan

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build:packages`
- `npm run build:web`


------
https://chatgpt.com/codex/tasks/task_e_68c57809c1c8832d805a32ba03ba4dc9