### PR TITLE
feat(serializer): add module header and quote object names in Prolog export

### DIFF
--- a/packages/serializer/src/toProlog.ts
+++ b/packages/serializer/src/toProlog.ts
@@ -11,12 +11,13 @@ const propToProlog = (p: StaticObject['properties'][number]): string => {
 
 export const toProlog = (plan: Plan): string => {
   const lines: string[] = [];
+  lines.push(':- module(plan, []).', '');
   lines.push(`room(size(${plan.room.W}, ${plan.room.H})).`);
   for (const o of plan.objects) {
     const props = o.properties?.map(propToProlog).filter(Boolean).join(', ');
     const propsList = props ? `[${props}]` : '[]';
     const r = o.rect;
-    lines.push(`static_object(${o.id}, ${o.type}, rect(${r.X}, ${r.Y}, ${r.W}, ${r.H}), ${propsList}).`);
+    lines.push(`static_object('${o.id}', ${o.type}, rect(${r.X}, ${r.Y}, ${r.W}, ${r.H}), ${propsList}).`);
   }
   if (plan.task) {
     lines.push(`\n% task spec`);


### PR DESCRIPTION
## Summary
- add `:- module(plan, []).` header to Prolog plan export
- wrap object identifiers in single quotes in generated `static_object` facts

## Testing
- `npm -w @planner/shared run build && npm -w @planner/serializer run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7ceb3c68c832da97b4e604e2705ca