### PR TITLE
Add configurable equipment clearances and window zones

### DIFF
--- a/apps/web/src/components/editor/config.ts
+++ b/apps/web/src/components/editor/config.ts
@@ -3,6 +3,12 @@ export const GRID_MM = 100;
 export const MIN_SIZE_MM = 100;
 export const PADDING_PX = 20;
 
+export const DEFAULT_CLEARANCES_MM = {
+  electrical_shield: 1000,
+  net_cabinet: 1000,
+  window: 1000,
+};
+
 // Человеко-читабельные названия (RU)
 export const TYPE_LABEL: Record<string, string> = {
   door: 'Дверь',

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "CommonJS",
+    "moduleResolution": "node",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
- centralize default clearances for equipment and windows in the editor and use them when computing forbidden zones
- expose window clearance calculations alongside parameterized equipment zones so the canvas renders access areas for all wall-mounted fixtures
- mirror the new window clearance logic in the shared rules package, add a window access rule, and tweak TypeScript module resolution so workspace builds succeed

## Testing
- npm -w @planner/shared run build
- npm -w @planner/geometry run build
- npm -w @planner/rules run build
- npm -w @planner/serializer run build
- npm -w @planner/web run build

------
https://chatgpt.com/codex/tasks/task_e_68c97ff09218832d9bea86204208a4a5