### PR TITLE
Refactor API export pipeline with modular NestJS architecture

### DIFF
--- a/apps/api/jest.config.js
+++ b/apps/api/jest.config.js
@@ -1,0 +1,29 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  testMatch: ['**/__tests__/**/*.spec.ts', '**/*.spec.ts'],
+  transform: {
+    '^.+\\.ts$': 'ts-jest',
+  },
+  collectCoverageFrom: [
+    'src/**/*.ts',
+    '!src/**/*.spec.ts',
+    '!src/**/__tests__/**',
+    '!src/main.ts',
+    '!src/**/*.module.ts',
+  ],
+  coverageDirectory: '../coverage',
+  coverageThreshold: {
+    global: {
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
+    },
+  },
+  moduleNameMapper: {
+    '^@planner/shared$': '<rootDir>/../../packages/shared/src',
+    '^@planner/serializer$': '<rootDir>/../../packages/serializer/src',
+  },
+};

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -5,21 +5,34 @@
   "scripts": {
     "start": "nest start",
     "start:dev": "nest start --watch",
-    "build": "nest build"
+    "build": "nest build",
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:cov": "jest --coverage",
+    "test:e2e": "jest --config ./test/jest-e2e.json"
   },
   "dependencies": {
     "@nestjs/common": "latest",
+    "@nestjs/config": "latest",
     "@nestjs/core": "latest",
     "@nestjs/platform-express": "latest",
-    "reflect-metadata": "latest",
-    "rxjs": "latest",
+    "@planner/serializer": "0.4.0",
     "@planner/shared": "0.4.0",
-    "@planner/serializer": "0.4.0"
+    "class-transformer": "latest",
+    "class-validator": "latest",
+    "reflect-metadata": "latest",
+    "rxjs": "latest"
   },
   "devDependencies": {
     "@nestjs/cli": "latest",
-    "typescript": "latest",
+    "@nestjs/testing": "latest",
+    "@types/jest": "latest",
+    "@types/supertest": "latest",
+    "jest": "latest",
+    "supertest": "latest",
+    "ts-jest": "latest",
     "ts-node": "latest",
-    "tsconfig-paths": "latest"
+    "tsconfig-paths": "latest",
+    "typescript": "latest"
   }
 }

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,5 +1,18 @@
 import { Module } from '@nestjs/common';
-import { ExportController } from './export.controller';
+import { ConfigModule } from '@nestjs/config';
+import { appConfig } from './config/app.config';
+import { ExportModule } from './export/export.module';
 
-@Module({ imports: [], controllers: [ExportController], providers: [] })
+/**
+ * Root NestJS application module.
+ */
+@Module({
+  imports: [
+    ConfigModule.forRoot({
+      isGlobal: true,
+      load: [() => appConfig],
+    }),
+    ExportModule,
+  ],
+})
 export class AppModule {}

--- a/apps/api/src/common/filters/http-exception.filter.ts
+++ b/apps/api/src/common/filters/http-exception.filter.ts
@@ -1,0 +1,59 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpException,
+  HttpStatus,
+  Logger,
+} from '@nestjs/common';
+import { Request, Response } from 'express';
+
+/**
+ * Global HTTP exception filter that normalizes error responses
+ * and logs request failures.
+ */
+@Catch()
+export class HttpExceptionFilter implements ExceptionFilter {
+  private readonly logger = new Logger(HttpExceptionFilter.name);
+
+  catch(exception: unknown, host: ArgumentsHost): void {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const request = ctx.getRequest<Request>();
+
+    const status =
+      exception instanceof HttpException
+        ? exception.getStatus()
+        : HttpStatus.INTERNAL_SERVER_ERROR;
+
+    const message = this.extractMessage(exception);
+
+    const errorResponse = {
+      statusCode: status,
+      timestamp: new Date().toISOString(),
+      path: request.url,
+      method: request.method,
+      message,
+    };
+
+    this.logger.error(
+      `${request.method} ${request.url} - ${status}`,
+      exception instanceof Error ? exception.stack : undefined,
+    );
+
+    response.status(status).json(errorResponse);
+  }
+
+  private extractMessage(exception: unknown): string | string[] {
+    if (exception instanceof HttpException) {
+      const res = exception.getResponse();
+      if (typeof res === 'string') {
+        return res;
+      }
+      const message = (res as { message?: string | string[] }).message;
+      return message ?? exception.message;
+    }
+
+    return 'Internal server error';
+  }
+}

--- a/apps/api/src/common/interceptors/logging.interceptor.ts
+++ b/apps/api/src/common/interceptors/logging.interceptor.ts
@@ -1,0 +1,38 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  Logger,
+  NestInterceptor,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+
+/**
+ * Logs every HTTP request duration and success/error state.
+ */
+@Injectable()
+export class LoggingInterceptor implements NestInterceptor {
+  private readonly logger = new Logger(LoggingInterceptor.name);
+
+  intercept(context: ExecutionContext, next: CallHandler): Observable<unknown> {
+    const request = context.switchToHttp().getRequest();
+    const { method, url } = request;
+    const started = Date.now();
+
+    return next.handle().pipe(
+      tap({
+        next: () => {
+          const elapsed = Date.now() - started;
+          this.logger.log(`${method} ${url} - ${elapsed}ms - SUCCESS`);
+        },
+        error: (error: Error) => {
+          const elapsed = Date.now() - started;
+          this.logger.error(
+            `${method} ${url} - ${elapsed}ms - ERROR: ${error.message}`,
+          );
+        },
+      }),
+    );
+  }
+}

--- a/apps/api/src/common/pipes/validation.pipe.ts
+++ b/apps/api/src/common/pipes/validation.pipe.ts
@@ -1,0 +1,56 @@
+import {
+  ArgumentMetadata,
+  BadRequestException,
+  Injectable,
+  PipeTransform,
+} from '@nestjs/common';
+import { plainToInstance } from 'class-transformer';
+import { validate, ValidationError } from 'class-validator';
+
+/**
+ * Validates incoming payloads using class-validator decorators applied to DTOs.
+ */
+@Injectable()
+export class ValidationPipe implements PipeTransform {
+  async transform(value: unknown, { metatype }: ArgumentMetadata): Promise<unknown> {
+    if (!metatype || this.isPrimitive(metatype)) {
+      return value;
+    }
+
+    const object = plainToInstance(metatype as new () => unknown, value);
+    const errors = await validate(object as object, {
+      whitelist: true,
+      forbidNonWhitelisted: true,
+      transform: true,
+    });
+
+    if (errors.length > 0) {
+      const messages = this.formatErrors(errors);
+      throw new BadRequestException({
+        message: 'Validation failed',
+        errors: messages,
+      });
+    }
+
+    return object;
+  }
+
+  private isPrimitive(metatype: unknown): boolean {
+    const types: unknown[] = [String, Boolean, Number, Array, Object];
+    return types.includes(metatype);
+  }
+
+  private formatErrors(errors: ValidationError[]): string[] {
+    return errors.flatMap((error) => {
+      if (error.constraints) {
+        return Object.values(error.constraints);
+      }
+
+      if (error.children && error.children.length > 0) {
+        return this.formatErrors(error.children);
+      }
+
+      return [];
+    });
+  }
+}

--- a/apps/api/src/config/app.config.ts
+++ b/apps/api/src/config/app.config.ts
@@ -1,0 +1,16 @@
+/**
+ * Application configuration
+ * Centralized place for runtime settings.
+ */
+export const appConfig = {
+  /** Server port (default 3333) */
+  port: parseInt(process.env.PORT || '3333', 10),
+  /** Allowed CORS origin */
+  corsOrigin: process.env.CORS_ORIGIN || '*',
+  /** Node environment */
+  nodeEnv: process.env.NODE_ENV || 'development',
+  /** Log level threshold */
+  logLevel: process.env.LOG_LEVEL || 'log',
+} as const;
+
+export type AppConfig = typeof appConfig;

--- a/apps/api/src/export.controller.ts
+++ b/apps/api/src/export.controller.ts
@@ -1,5 +1,0 @@
-import { Controller, Post, Body, Header } from '@nestjs/common';
-import type { Plan } from '@planner/shared';
-import { toProlog } from '@planner/serializer';
-@Controller('export')
-export class ExportController { @Post('plan.pl') @Header('Content-Type','text/plain; charset=utf-8') export(@Body() plan: Plan){ return toProlog(plan);} }

--- a/apps/api/src/export/__tests__/export.controller.spec.ts
+++ b/apps/api/src/export/__tests__/export.controller.spec.ts
@@ -1,0 +1,76 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExportPlanDto } from '../dto/export-plan.dto';
+import { ExportController } from '../export.controller';
+import { ExportService } from '../export.service';
+
+describe('ExportController', () => {
+  let controller: ExportController;
+  let service: ExportService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ExportController],
+      providers: [ExportService],
+    }).compile();
+
+    controller = module.get(ExportController);
+    service = module.get(ExportService);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+
+  describe('exportPlan', () => {
+    it('returns prolog payload for valid plan', () => {
+      const plan: ExportPlanDto = {
+        room: { W: 10000, H: 8000 },
+        objects: [],
+      };
+
+      const prolog = ':- module(plan, []).\nroom(size(10000, 8000)).';
+
+      jest.spyOn(service, 'exportToPrologFormat').mockReturnValue(prolog);
+      jest.spyOn(service, 'getPlanStatistics').mockReturnValue({
+        roomArea: 80,
+        objectsCount: 0,
+        objectsByType: {},
+        totalObjectArea: 0,
+        occupancyRate: 0,
+      });
+
+      const result = controller.exportPlan(plan);
+
+      expect(result).toBe(prolog);
+      expect(service.exportToPrologFormat).toHaveBeenCalledWith(plan);
+      expect(service.getPlanStatistics).toHaveBeenCalledWith(plan);
+    });
+
+    it('delegates work to service layer', () => {
+      const plan: ExportPlanDto = {
+        room: { W: 5000, H: 4000 },
+        objects: [
+          {
+            id: 'test-1',
+            type: 'door',
+            rect: { X: 0, Y: 0, W: 900, H: 100 },
+            properties: [],
+          },
+        ],
+      };
+
+      jest.spyOn(service, 'exportToPrologFormat').mockReturnValue('code');
+      jest.spyOn(service, 'getPlanStatistics').mockReturnValue({
+        roomArea: 20,
+        objectsCount: 1,
+        objectsByType: { door: 1 },
+        totalObjectArea: 0.09,
+        occupancyRate: 0,
+      });
+
+      controller.exportPlan(plan);
+
+      expect(service.exportToPrologFormat).toHaveBeenCalledWith(plan);
+    });
+  });
+});

--- a/apps/api/src/export/__tests__/export.service.spec.ts
+++ b/apps/api/src/export/__tests__/export.service.spec.ts
@@ -1,0 +1,166 @@
+import { BadRequestException } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import { ExportPlanDto } from '../dto/export-plan.dto';
+import { ExportService } from '../export.service';
+
+describe('ExportService', () => {
+  let service: ExportService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ExportService],
+    }).compile();
+
+    service = module.get(ExportService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+
+  describe('exportToPrologFormat', () => {
+    it('exports plan to prolog code', () => {
+      const plan: ExportPlanDto = {
+        room: { W: 10000, H: 8000 },
+        objects: [
+          {
+            id: 'door-1',
+            type: 'door',
+            rect: { X: 0, Y: 2000, W: 100, H: 900 },
+            properties: [],
+          },
+        ],
+      };
+
+      const result = service.exportToPrologFormat(plan);
+
+      expect(result).toContain(':- module(plan, [])');
+      expect(result).toContain('room(size(10000, 8000))');
+      expect(result).toContain("static_object('door-1'");
+    });
+
+    it('includes task specification when provided', () => {
+      const plan: ExportPlanDto = {
+        room: { W: 10000, H: 8000 },
+        objects: [],
+        task: { count: 10, size: { W: 1200, H: 800 } },
+      };
+
+      const result = service.exportToPrologFormat(plan);
+
+      expect(result).toContain('task(10, size(1200, 800))');
+    });
+
+    it('throws error when object is outside room', () => {
+      const plan: ExportPlanDto = {
+        room: { W: 10000, H: 8000 },
+        objects: [
+          {
+            id: 'out-1',
+            type: 'door',
+            rect: { X: 10000, Y: 0, W: 900, H: 100 },
+            properties: [],
+          },
+        ],
+      };
+
+      expect(() => service.exportToPrologFormat(plan)).toThrow(BadRequestException);
+    });
+  });
+
+  describe('validatePlanStructure', () => {
+    it('allows valid plan', () => {
+      const plan: ExportPlanDto = {
+        room: { W: 10000, H: 8000 },
+        objects: [
+          {
+            id: 'obj-1',
+            type: 'door',
+            rect: { X: 0, Y: 0, W: 900, H: 100 },
+            properties: [],
+          },
+        ],
+      };
+
+      expect(() => service.validatePlanStructure(plan)).not.toThrow();
+    });
+
+    it('rejects objects outside room', () => {
+      const plan: ExportPlanDto = {
+        room: { W: 10000, H: 8000 },
+        objects: [
+          {
+            id: 'obj-1',
+            type: 'door',
+            rect: { X: 10001, Y: 0, W: 900, H: 100 },
+            properties: [],
+          },
+        ],
+      };
+
+      expect(() => service.validatePlanStructure(plan)).toThrow(
+        'Objects outside room boundaries',
+      );
+    });
+
+    it('rejects duplicate ids', () => {
+      const plan: ExportPlanDto = {
+        room: { W: 10000, H: 8000 },
+        objects: [
+          {
+            id: 'obj-1',
+            type: 'door',
+            rect: { X: 0, Y: 0, W: 900, H: 100 },
+            properties: [],
+          },
+          {
+            id: 'obj-1',
+            type: 'window',
+            rect: { X: 1000, Y: 0, W: 1500, H: 200 },
+            properties: [],
+          },
+        ],
+      };
+
+      expect(() => service.validatePlanStructure(plan)).toThrow(
+        'Duplicate object IDs',
+      );
+    });
+  });
+
+  describe('getPlanStatistics', () => {
+    it('computes statistics summary', () => {
+      const plan: ExportPlanDto = {
+        room: { W: 10000, H: 8000 },
+        objects: [
+          {
+            id: 'door-1',
+            type: 'door',
+            rect: { X: 0, Y: 0, W: 900, H: 100 },
+            properties: [],
+          },
+          {
+            id: 'door-2',
+            type: 'door',
+            rect: { X: 1000, Y: 0, W: 900, H: 100 },
+            properties: [],
+          },
+          {
+            id: 'window-1',
+            type: 'window',
+            rect: { X: 2000, Y: 0, W: 1500, H: 200 },
+            properties: [],
+          },
+        ],
+      };
+
+      const stats = service.getPlanStatistics(plan);
+
+      expect(stats.roomArea).toBe(80);
+      expect(stats.objectsCount).toBe(3);
+      expect(stats.objectsByType).toEqual({ door: 2, window: 1 });
+      expect(stats.totalObjectArea).toBeGreaterThan(0);
+      expect(stats.occupancyRate).toBeGreaterThan(0);
+    });
+  });
+});

--- a/apps/api/src/export/dto/export-plan.dto.ts
+++ b/apps/api/src/export/dto/export-plan.dto.ts
@@ -1,0 +1,117 @@
+import {
+  ArrayMinSize,
+  IsArray,
+  IsBoolean,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Min,
+  ValidateNested,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+
+/**
+ * DTO describing a plan size (width/height in millimeters).
+ */
+export class SizeDto {
+  @IsNumber()
+  @Min(100, { message: 'Width must be at least 100mm' })
+  W!: number;
+
+  @IsNumber()
+  @Min(100, { message: 'Height must be at least 100mm' })
+  H!: number;
+}
+
+/**
+ * DTO describing a rectangle position/size.
+ */
+export class RectDto {
+  @IsNumber()
+  @Min(0, { message: 'X coordinate must be non-negative' })
+  X!: number;
+
+  @IsNumber()
+  @Min(0, { message: 'Y coordinate must be non-negative' })
+  Y!: number;
+
+  @IsNumber()
+  @Min(1, { message: 'Width must be at least 1mm' })
+  W!: number;
+
+  @IsNumber()
+  @Min(1, { message: 'Height must be at least 1mm' })
+  H!: number;
+}
+
+/**
+ * DTO describing a generic property entry associated with an object.
+ */
+export class PropertyDto {
+  @IsString()
+  kind!: string;
+
+  @IsOptional()
+  value?: unknown;
+}
+
+/**
+ * DTO describing a static object placed inside a room.
+ */
+export class StaticObjectDto {
+  @IsString()
+  id!: string;
+
+  @IsString()
+  type!: string;
+
+  @ValidateNested()
+  @Type(() => RectDto)
+  rect!: RectDto;
+
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => PropertyDto)
+  properties!: PropertyDto[];
+
+  @IsOptional()
+  @IsNumber()
+  orientation?: number;
+
+  @IsOptional()
+  @IsBoolean()
+  requiresWallAnchor?: boolean;
+}
+
+/**
+ * DTO describing optional task specification for the plan.
+ */
+export class TaskSpecDto {
+  @IsNumber()
+  @Min(1, { message: 'Task count must be at least 1' })
+  count!: number;
+
+  @ValidateNested()
+  @Type(() => SizeDto)
+  size!: SizeDto;
+}
+
+/**
+ * Top-level DTO used to validate payload for export endpoint.
+ */
+export class ExportPlanDto {
+  @ValidateNested()
+  @Type(() => SizeDto)
+  room!: SizeDto;
+
+  @IsArray()
+  @ArrayMinSize(0)
+  @ValidateNested({ each: true })
+  @Type(() => StaticObjectDto)
+  objects!: StaticObjectDto[];
+
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => TaskSpecDto)
+  task?: TaskSpecDto;
+}

--- a/apps/api/src/export/export.controller.ts
+++ b/apps/api/src/export/export.controller.ts
@@ -1,0 +1,40 @@
+import {
+  Body,
+  Controller,
+  Header,
+  HttpCode,
+  HttpStatus,
+  Logger,
+  Post,
+} from '@nestjs/common';
+import { ExportPlanDto } from './dto/export-plan.dto';
+import { ExportService } from './export.service';
+
+/**
+ * HTTP endpoints for exporting planner data to Prolog format.
+ */
+@Controller('export')
+export class ExportController {
+  private readonly logger = new Logger(ExportController.name);
+
+  constructor(private readonly exportService: ExportService) {}
+
+  /**
+   * POST /export/plan.pl
+   * Accepts plan payload and returns Prolog serialization.
+   */
+  @Post('plan.pl')
+  @HttpCode(HttpStatus.OK)
+  @Header('Content-Type', 'text/plain; charset=utf-8')
+  exportPlan(@Body() plan: ExportPlanDto): string {
+    this.logger.log(
+      `Received export request for plan with ${plan.objects.length} objects`,
+    );
+
+    const prologCode = this.exportService.exportToPrologFormat(plan);
+    const stats = this.exportService.getPlanStatistics(plan);
+    this.logger.log(`Export completed. Stats: ${JSON.stringify(stats)}`);
+
+    return prologCode;
+  }
+}

--- a/apps/api/src/export/export.module.ts
+++ b/apps/api/src/export/export.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { ExportController } from './export.controller';
+import { ExportService } from './export.service';
+
+/**
+ * Nest module encapsulating export feature.
+ */
+@Module({
+  controllers: [ExportController],
+  providers: [ExportService],
+  exports: [ExportService],
+})
+export class ExportModule {}

--- a/apps/api/src/export/export.service.ts
+++ b/apps/api/src/export/export.service.ts
@@ -1,0 +1,92 @@
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
+import { toProlog } from '@planner/serializer';
+import type { Plan } from '@planner/shared';
+import { ExportPlanDto } from './dto/export-plan.dto';
+
+/**
+ * Handles business logic for exporting planner data.
+ */
+@Injectable()
+export class ExportService {
+  private readonly logger = new Logger(ExportService.name);
+
+  /**
+   * Converts a validated plan into Prolog representation.
+   * @param plan plan payload.
+   * @returns serialized Prolog program.
+   */
+  exportToPrologFormat(plan: ExportPlanDto): string {
+    this.logger.debug(
+      `Exporting plan: room=${plan.room.W}x${plan.room.H}, objects=${plan.objects.length}`,
+    );
+
+    this.validatePlanStructure(plan);
+
+    try {
+      const prologCode = toProlog(plan as unknown as Plan);
+      this.logger.log('Plan successfully exported to Prolog');
+      return prologCode;
+    } catch (error) {
+      this.logger.error('Failed to serialize plan', error instanceof Error ? error.stack : undefined);
+      throw error;
+    }
+  }
+
+  /**
+   * Performs structural validation of plan data beyond DTO validation.
+   */
+  validatePlanStructure(plan: ExportPlanDto): void {
+    const outsideObjects = plan.objects.filter((object) => {
+      const { X, Y, W, H } = object.rect;
+      return X < 0 || Y < 0 || X + W > plan.room.W || Y + H > plan.room.H;
+    });
+
+    if (outsideObjects.length > 0) {
+      const ids = outsideObjects.map((obj) => obj.id).join(', ');
+      throw new BadRequestException(`Objects outside room boundaries: ${ids}`);
+    }
+
+    const seen = new Set<string>();
+    const duplicates = new Set<string>();
+    for (const object of plan.objects) {
+      if (seen.has(object.id)) {
+        duplicates.add(object.id);
+      }
+      seen.add(object.id);
+    }
+
+    if (duplicates.size > 0) {
+      throw new BadRequestException(
+        `Duplicate object IDs: ${Array.from(duplicates).join(', ')}`,
+      );
+    }
+
+    this.logger.debug('Plan structure validation passed');
+  }
+
+  /**
+   * Aggregates statistics describing plan occupancy information.
+   */
+  getPlanStatistics(plan: ExportPlanDto) {
+    const roomArea = (plan.room.W * plan.room.H) / 1_000_000;
+    const objectsByType = plan.objects.reduce<Record<string, number>>(
+      (acc, object) => {
+        acc[object.type] = (acc[object.type] || 0) + 1;
+        return acc;
+      },
+      {},
+    );
+
+    const totalObjectArea = plan.objects.reduce((sum, object) => {
+      return sum + (object.rect.W * object.rect.H) / 1_000_000;
+    }, 0);
+
+    return {
+      roomArea: Math.round(roomArea * 100) / 100,
+      objectsCount: plan.objects.length,
+      objectsByType,
+      totalObjectArea: Math.round(totalObjectArea * 100) / 100,
+      occupancyRate: roomArea === 0 ? 0 : Math.round((totalObjectArea / roomArea) * 100),
+    };
+  }
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,4 +1,36 @@
 import 'reflect-metadata';
+import { Logger } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
+import { ConfigService } from '@nestjs/config';
 import { AppModule } from './app.module';
-(async function bootstrap(){ const app = await NestFactory.create(AppModule,{cors:true}); await app.listen(3333); console.log('API http://localhost:3333'); })();
+import { HttpExceptionFilter } from './common/filters/http-exception.filter';
+import { LoggingInterceptor } from './common/interceptors/logging.interceptor';
+import { ValidationPipe } from './common/pipes/validation.pipe';
+import { appConfig } from './config/app.config';
+
+async function bootstrap(): Promise<void> {
+  const logger = new Logger('Bootstrap');
+  const app = await NestFactory.create(AppModule, {
+    cors: {
+      origin: appConfig.corsOrigin,
+      credentials: true,
+    },
+  });
+
+  app.useGlobalPipes(new ValidationPipe());
+  app.useGlobalFilters(new HttpExceptionFilter());
+  app.useGlobalInterceptors(new LoggingInterceptor());
+
+  const configService = app.get(ConfigService);
+  const port = configService.get<number>('port', appConfig.port);
+  const corsOrigin = configService.get<string>('corsOrigin', appConfig.corsOrigin);
+  const nodeEnv = configService.get<string>('nodeEnv', appConfig.nodeEnv);
+
+  await app.listen(port);
+
+  logger.log(`🚀 API is running on http://localhost:${port}`);
+  logger.log(`📝 Environment: ${nodeEnv}`);
+  logger.log(`🌍 CORS origin: ${corsOrigin}`);
+}
+
+bootstrap();

--- a/apps/api/test/export.e2e-spec.ts
+++ b/apps/api/test/export.e2e-spec.ts
@@ -1,0 +1,106 @@
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+import * as request from 'supertest';
+import { AppModule } from '../src/app.module';
+import { HttpExceptionFilter } from '../src/common/filters/http-exception.filter';
+
+describe('Export (e2e)', () => {
+  let app: INestApplication;
+
+  beforeEach(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe());
+    app.useGlobalFilters(new HttpExceptionFilter());
+
+    await app.init();
+  });
+
+  afterEach(async () => {
+    await app.close();
+  });
+
+  describe('/export/plan.pl (POST)', () => {
+    it('exports valid plan', async () => {
+      const plan = {
+        room: { W: 10000, H: 8000 },
+        objects: [
+          {
+            id: 'door-1',
+            type: 'door',
+            rect: { X: 0, Y: 2000, W: 100, H: 900 },
+            properties: [],
+          },
+        ],
+      };
+
+      const response = await request(app.getHttpServer())
+        .post('/export/plan.pl')
+        .send(plan)
+        .expect(200)
+        .expect('Content-Type', /text\/plain/);
+
+      expect(response.text).toContain(':- module(plan, [])');
+      expect(response.text).toContain('room(size(10000, 8000))');
+      expect(response.text).toContain("static_object('door-1'");
+    });
+
+    it('rejects plan with invalid room dimensions', async () => {
+      const plan = {
+        room: { W: -100, H: 8000 },
+        objects: [],
+      };
+
+      const response = await request(app.getHttpServer())
+        .post('/export/plan.pl')
+        .send(plan)
+        .expect(400);
+
+      expect(response.body.message).toBe('Validation failed');
+      expect(response.body.errors).toBeDefined();
+    });
+
+    it('rejects object outside room', async () => {
+      const plan = {
+        room: { W: 10000, H: 8000 },
+        objects: [
+          {
+            id: 'out-1',
+            type: 'door',
+            rect: { X: 10000, Y: 0, W: 900, H: 100 },
+            properties: [],
+          },
+        ],
+      };
+
+      const response = await request(app.getHttpServer())
+        .post('/export/plan.pl')
+        .send(plan)
+        .expect(400);
+
+      expect(response.body.message).toContain('outside room boundaries');
+    });
+
+    it('handles task specification', async () => {
+      const plan = {
+        room: { W: 10000, H: 8000 },
+        objects: [],
+        task: { count: 10, size: { W: 1200, H: 800 } },
+      };
+
+      const response = await request(app.getHttpServer())
+        .post('/export/plan.pl')
+        .send(plan)
+        .expect(200);
+
+      expect(response.text).toContain('task(10, size(1200, 800))');
+    });
+
+    it('rejects empty body', async () => {
+      await request(app.getHttpServer()).post('/export/plan.pl').send().expect(400);
+    });
+  });
+});

--- a/apps/api/test/jest-e2e.json
+++ b/apps/api/test/jest-e2e.json
@@ -1,0 +1,13 @@
+{
+  "moduleFileExtensions": ["js", "json", "ts"],
+  "rootDir": "..",
+  "testEnvironment": "node",
+  "testRegex": ".e2e-spec.ts$",
+  "transform": {
+    "^.+\\.(t|j)s$": "ts-jest"
+  },
+  "moduleNameMapper": {
+    "^@planner/shared$": "<rootDir>/../packages/shared/src",
+    "^@planner/serializer$": "<rootDir>/../packages/serializer/src"
+  }
+}


### PR DESCRIPTION
## Summary
- restructure the API into a dedicated export module with service logic and DTO validation
- add global validation pipe, logging interceptor, and HTTP exception filter for consistent handling
- introduce Jest configuration with unit and e2e tests covering the export controller and service

## Testing
- npm run test -w @planner/api *(fails: `jest` not found because new dev dependencies could not be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e27f6640a4832d83601b5a783d5e37