### PR TITLE
Refactor canvas view into dedicated hook

### DIFF
--- a/apps/web/src/components/editor/hooks/__tests__/useCanvasView.test.ts
+++ b/apps/web/src/components/editor/hooks/__tests__/useCanvasView.test.ts
@@ -1,0 +1,76 @@
+import { act, renderHook } from '@testing-library/react';
+import { useCanvasView } from '../useCanvasView';
+
+describe('useCanvasView', () => {
+  const defaultOptions = {
+    roomSize: { W: 10000, H: 8000 },
+    containerSize: { w: 800, h: 600 },
+    pxPerMm: 0.1,
+    padding: 20,
+  } as const;
+
+  it('calculates fit within expected bounds', () => {
+    const { result } = renderHook(() => useCanvasView(defaultOptions));
+
+    expect(result.current.fit).toBeGreaterThan(0);
+    expect(result.current.fit).toBeLessThanOrEqual(1);
+  });
+
+  it('zooms at center and respects max zoom', () => {
+    const { result } = renderHook(() => useCanvasView(defaultOptions));
+
+    act(() => {
+      result.current.zoomAtCenter(2);
+      result.current.zoomAtCenter(2);
+      result.current.zoomAtCenter(2);
+    });
+
+    expect(result.current.view.zoom).toBeLessThanOrEqual(10);
+    expect(result.current.view.zoom).toBeGreaterThan(1);
+  });
+
+  it('resets the view state', () => {
+    const { result } = renderHook(() => useCanvasView(defaultOptions));
+
+    act(() => {
+      result.current.zoomAtCenter(1.5);
+      result.current.setPan(100, 150);
+    });
+
+    expect(result.current.view.zoom).not.toBe(1);
+    expect(result.current.view.panX).toBe(100);
+
+    act(() => {
+      result.current.resetView();
+    });
+
+    expect(result.current.view).toEqual({ zoom: 1, panX: 0, panY: 0 });
+  });
+
+  it('handles wheel events using pointer position from stageRef', () => {
+    let prevented = false;
+    const preventDefault = () => {
+      prevented = true;
+    };
+    const stageRef = {
+      current: {
+        getPointerPosition: () => ({ x: 100, y: 120 }),
+        width: () => 800,
+        height: () => 600,
+      },
+    } as const;
+
+    const { result } = renderHook(() =>
+      useCanvasView({ ...defaultOptions, stageRef })
+    );
+
+    act(() => {
+      result.current.handleWheel({
+        evt: { preventDefault, deltaY: -100 },
+      } as any);
+    });
+
+    expect(prevented).toBe(true);
+    expect(result.current.view.zoom).toBeGreaterThan(1);
+  });
+});

--- a/apps/web/src/components/editor/hooks/index.ts
+++ b/apps/web/src/components/editor/hooks/index.ts
@@ -1,8 +1,8 @@
 'use client';
 import React from 'react';
-import { usePlanStore } from '../../store/planStore';
-
-export type View = { zoom: number; panX: number; panY: number };
+import { usePlanStore } from '../../../store/planStore';
+export type { CanvasView as View } from './useCanvasView';
+export { useCanvasView } from './useCanvasView';
 
 export const useContainerSize = (ref: React.RefObject<HTMLDivElement | null>) => {
   const [size, setSize] = React.useState({ w: 800, h: 600 });
@@ -23,7 +23,7 @@ export const useContainerSize = (ref: React.RefObject<HTMLDivElement | null>) =>
 
 export const useEditorHotkeys = (
   zoomAtCenter: (factor: number) => void,
-  setView: React.Dispatch<React.SetStateAction<View>>,
+  resetView: () => void,
   setGhost: (g: any) => void,
   updateGhostAt: () => void
 ) => {
@@ -45,7 +45,7 @@ export const useEditorHotkeys = (
       }
       if (e.key === '0' || e.key.toLowerCase() === 'f') {
         e.preventDefault();
-        setView({ zoom: 1, panX: 0, panY: 0 });
+        resetView();
       }
       if (e.key === 'Escape') {
         setPlacingType(undefined);
@@ -77,7 +77,17 @@ export const useEditorHotkeys = (
       window.removeEventListener('keydown', onKeyDown);
       window.removeEventListener('keyup', onKeyUp);
     };
-  }, [zoomAtCenter, setView, setPlacingType, deleteSelected, placingType, setGhost, updateGhostAt, copySelected, copied]);
+  }, [
+    zoomAtCenter,
+    resetView,
+    setPlacingType,
+    deleteSelected,
+    placingType,
+    setGhost,
+    updateGhostAt,
+    copySelected,
+    copied,
+  ]);
 
   return spacePressed;
 };

--- a/apps/web/src/components/editor/hooks/useCanvasView.ts
+++ b/apps/web/src/components/editor/hooks/useCanvasView.ts
@@ -1,0 +1,134 @@
+import * as React from 'react';
+import type { KonvaEventObject } from 'konva/lib/Node';
+import { clamp } from '@planner/geometry';
+
+export type CanvasView = {
+  zoom: number;
+  panX: number;
+  panY: number;
+};
+
+export interface UseCanvasViewOptions {
+  roomSize: { W: number; H: number };
+  containerSize: { w: number; h: number };
+  pxPerMm: number;
+  padding: number;
+  stageRef?: React.RefObject<any>;
+  minZoom?: number;
+  maxZoom?: number;
+}
+
+export interface UseCanvasViewResult {
+  view: CanvasView;
+  setView: React.Dispatch<React.SetStateAction<CanvasView>>;
+  fit: number;
+  mm2px: number;
+  zoomAt: (x: number, y: number, factor: number) => void;
+  zoomAtCenter: (factor: number) => void;
+  resetView: () => void;
+  setPan: (panX: number, panY: number) => void;
+  applyPanDelta: (dx: number, dy: number) => void;
+  handleWheel: (evt: KonvaEventObject<WheelEvent>) => void;
+}
+
+/**
+ * Manages zooming and panning state for the editor canvas.
+ */
+export function useCanvasView({
+  roomSize,
+  containerSize,
+  pxPerMm,
+  padding,
+  stageRef,
+  minZoom = 0.2,
+  maxZoom = 10,
+}: UseCanvasViewOptions): UseCanvasViewResult {
+  const [view, setView] = React.useState<CanvasView>({ zoom: 1, panX: 0, panY: 0 });
+
+  const fit = React.useMemo(() => {
+    const roomPxW = roomSize.W * pxPerMm;
+    const roomPxH = roomSize.H * pxPerMm;
+    const scale =
+      Math.min(
+        containerSize.w / (roomPxW + padding * 2),
+        containerSize.h / (roomPxH + padding * 2)
+      ) || 1;
+    return Math.max(1e-6, Math.floor(scale * 1000) / 1000);
+  }, [containerSize.h, containerSize.w, padding, pxPerMm, roomSize.H, roomSize.W]);
+
+  const mm2px = pxPerMm * fit * view.zoom;
+
+  const zoomAt = React.useCallback(
+    (sx: number, sy: number, factor: number) => {
+      setView((prev) => {
+        const oldZoom = prev.zoom;
+        const nextZoom = clamp(oldZoom * factor, minZoom, maxZoom);
+        if (nextZoom === oldZoom) {
+          return prev;
+        }
+
+        const baseX = padding;
+        const baseY = padding;
+        const oldMm2px = pxPerMm * fit * oldZoom;
+        const newMm2px = pxPerMm * fit * nextZoom;
+
+        const newPanX = sx - baseX - ((sx - baseX - prev.panX) / oldMm2px) * newMm2px;
+        const newPanY = sy - baseY - ((sy - baseY - prev.panY) / oldMm2px) * newMm2px;
+
+        return {
+          zoom: nextZoom,
+          panX: newPanX,
+          panY: newPanY,
+        };
+      });
+    },
+    [fit, maxZoom, minZoom, padding, pxPerMm]
+  );
+
+  const zoomAtCenter = React.useCallback(
+    (factor: number) => {
+      const stage = stageRef?.current as { width?: () => number; height?: () => number } | null;
+      const sx = (stage?.width?.() ?? containerSize.w) / 2;
+      const sy = (stage?.height?.() ?? containerSize.h) / 2;
+      zoomAt(sx, sy, factor);
+    },
+    [containerSize.h, containerSize.w, stageRef, zoomAt]
+  );
+
+  const resetView = React.useCallback(() => {
+    setView({ zoom: 1, panX: 0, panY: 0 });
+  }, []);
+
+  const setPan = React.useCallback((panX: number, panY: number) => {
+    setView((prev) => ({ ...prev, panX, panY }));
+  }, []);
+
+  const applyPanDelta = React.useCallback((dx: number, dy: number) => {
+    setView((prev) => ({ ...prev, panX: prev.panX + dx, panY: prev.panY + dy }));
+  }, []);
+
+  const handleWheel = React.useCallback(
+    (evt: KonvaEventObject<WheelEvent>) => {
+      evt.evt.preventDefault();
+      const stage = stageRef?.current;
+      const pointer = stage?.getPointerPosition?.();
+      if (!pointer) return;
+      const direction = evt.evt.deltaY > 0 ? 1 / 1.1 : 1.1;
+      zoomAt(pointer.x, pointer.y, direction);
+    },
+    [stageRef, zoomAt]
+  );
+
+  return {
+    view,
+    setView,
+    fit,
+    mm2px,
+    zoomAt,
+    zoomAtCenter,
+    resetView,
+    setPan,
+    applyPanDelta,
+    handleWheel,
+  };
+}


### PR DESCRIPTION
## Summary
- extract canvas zoom and pan state into a reusable `useCanvasView` hook
- update `EditorCanvas` and editor hotkey utilities to consume the new view helpers
- add unit coverage validating the canvas view hook behaviour

## Testing
- npm run build:packages
- npm run build -w @planner/web

------
https://chatgpt.com/codex/tasks/task_e_68e360c41eb0832dbb91ff5d3ddf7284