### PR TITLE
Refactor canvas zoom and pan into reusable hook

### DIFF
--- a/apps/web/src/components/EditorCanvas.tsx
+++ b/apps/web/src/components/EditorCanvas.tsx
@@ -19,7 +19,7 @@ import {
   computeEquipmentZone,
   computeWindowZone,
 } from '@planner/geometry';
-import { useContainerSize, useEditorHotkeys, View } from './editor/hooks';
+import { useContainerSize, useEditorHotkeys, useCanvasView } from './editor/hooks';
 import {
   Grid,
   Room,
@@ -49,19 +49,20 @@ export const EditorCanvas: React.FC = () => {
     copied,
   } = usePlanStore();
 
-  // fit без учёта zoom
-  const roomPxBase = { W: plan.room.W * PX_PER_MM, H: plan.room.H * PX_PER_MM };
-  const fit = React.useMemo(() => {
-    const s =
-      Math.min(
-        size.w / (roomPxBase.W + PADDING_PX * 2),
-        size.h / (roomPxBase.H + PADDING_PX * 2)
-      ) || 1;
-    return Math.max(1e-6, Math.floor(s * 1000) / 1000);
-  }, [size.w, size.h, roomPxBase.W, roomPxBase.H]);
+  const { view, fit, mm2px, zoomAtPoint, zoomAtCenter, resetView, setPan } =
+    useCanvasView({
+      roomSize: plan.room,
+      containerSize: size,
+      pxPerMm: PX_PER_MM,
+      padding: PADDING_PX,
+    });
 
-  const [view, setView] = React.useState<View>({ zoom: 1, panX: 0, panY: 0 });
-  const mm2px = PX_PER_MM * fit * view.zoom;
+  const zoomStageCenter = React.useCallback(
+    (factor: number) => {
+      zoomAtCenter(factor, { width: size.w, height: size.h });
+    },
+    [size.h, size.w, zoomAtCenter]
+  );
 
   // панорамирование
   const [isPanning, setIsPanning] = React.useState(false);
@@ -87,42 +88,12 @@ export const EditorCanvas: React.FC = () => {
     H: number;
   } | null>(null);
 
-  // ======= зум =======
-  const zoomAt = React.useCallback(
-    (sx: number, sy: number, factor: number) => {
-      setView((prev) => {
-        const old = prev.zoom;
-        const next = clamp(old * factor, 0.2, 10);
-        if (next === old) return prev;
-        const baseX = PADDING_PX,
-          baseY = PADDING_PX;
-        const oldMm2px = PX_PER_MM * fit * old;
-        const newMm2px = PX_PER_MM * fit * next;
-        const newPanX =
-          sx -
-          baseX -
-          ((sx - baseX - prev.panX) / oldMm2px) * newMm2px;
-        const newPanY =
-          sy -
-          baseY -
-          ((sy - baseY - prev.panY) / oldMm2px) * newMm2px;
-        return { zoom: next, panX: newPanX, panY: newPanY };
-      });
-    },
-    [fit]
-  );
-
-  const zoomAtCenter = React.useCallback(
-    (factor: number) => {
-      const stage = stageRef.current as any;
-      const sx = (stage?.width() ?? size.w) / 2;
-      const sy = (stage?.height() ?? size.h) / 2;
-      zoomAt(sx, sy, factor);
-    },
-    [size.w, size.h, zoomAt]
-  );
-
-  const spacePressed = useEditorHotkeys(zoomAtCenter, setView, setGhost, updateGhostAt);
+  const spacePressed = useEditorHotkeys({
+    zoomAtCenter: zoomStageCenter,
+    resetView,
+    setGhost,
+    updateGhostAt,
+  });
 
   // Завершать пан при mouseup/blur
   React.useEffect(() => {
@@ -141,7 +112,7 @@ export const EditorCanvas: React.FC = () => {
     const p = stage.getPointerPosition();
     if (!p) return;
     const dir = e.evt.deltaY > 0 ? 1 / 1.1 : 1.1;
-    zoomAt(p.x, p.y, dir);
+    zoomAtPoint(p.x, p.y, dir);
   };
 
   // Базовые вычисления
@@ -240,7 +211,7 @@ export const EditorCanvas: React.FC = () => {
     }
     const dx = e.evt.clientX - ps.x,
       dy = e.evt.clientY - ps.y;
-    setView((v) => ({ ...v, panX: ps.panX + dx, panY: ps.panY + dy }));
+    setPan(ps.panX + dx, ps.panY + dy);
   };
   const handleClick = () => {
     if (!placingType || !ghost) return;

--- a/apps/web/src/components/editor/hooks.ts
+++ b/apps/web/src/components/editor/hooks.ts
@@ -1,8 +1,9 @@
 'use client';
 import React from 'react';
 import { usePlanStore } from '../../store/planStore';
+import type { CanvasView } from './hooks/useCanvasView';
 
-export type View = { zoom: number; panX: number; panY: number };
+export type View = CanvasView;
 
 export const useContainerSize = (ref: React.RefObject<HTMLDivElement | null>) => {
   const [size, setSize] = React.useState({ w: 800, h: 600 });
@@ -21,12 +22,19 @@ export const useContainerSize = (ref: React.RefObject<HTMLDivElement | null>) =>
   return size;
 };
 
-export const useEditorHotkeys = (
-  zoomAtCenter: (factor: number) => void,
-  setView: React.Dispatch<React.SetStateAction<View>>,
-  setGhost: (g: any) => void,
-  updateGhostAt: () => void
-) => {
+interface EditorHotkeysOptions {
+  zoomAtCenter: (factor: number) => void;
+  resetView: () => void;
+  setGhost: (ghost: any) => void;
+  updateGhostAt: () => void;
+}
+
+export const useEditorHotkeys = ({
+  zoomAtCenter,
+  resetView,
+  setGhost,
+  updateGhostAt,
+}: EditorHotkeysOptions) => {
   const { setPlacingType, deleteSelected, placingType, copySelected, copied } = usePlanStore();
   const spacePressed = React.useRef(false);
 
@@ -45,7 +53,7 @@ export const useEditorHotkeys = (
       }
       if (e.key === '0' || e.key.toLowerCase() === 'f') {
         e.preventDefault();
-        setView({ zoom: 1, panX: 0, panY: 0 });
+        resetView();
       }
       if (e.key === 'Escape') {
         setPlacingType(undefined);
@@ -55,11 +63,11 @@ export const useEditorHotkeys = (
         e.preventDefault();
         deleteSelected();
       }
-      if ((e.key.toLowerCase() === 'c') && (e.metaKey || e.ctrlKey) && !placingType) {
+      if (e.key.toLowerCase() === 'c' && (e.metaKey || e.ctrlKey) && !placingType) {
         e.preventDefault();
         copySelected();
       }
-      if ((e.key.toLowerCase() === 'v') && (e.metaKey || e.ctrlKey)) {
+      if (e.key.toLowerCase() === 'v' && (e.metaKey || e.ctrlKey)) {
         if (copied) {
           e.preventDefault();
           setPlacingType(copied.type);
@@ -77,7 +85,9 @@ export const useEditorHotkeys = (
       window.removeEventListener('keydown', onKeyDown);
       window.removeEventListener('keyup', onKeyUp);
     };
-  }, [zoomAtCenter, setView, setPlacingType, deleteSelected, placingType, setGhost, updateGhostAt, copySelected, copied]);
+  }, [zoomAtCenter, resetView, setPlacingType, deleteSelected, placingType, setGhost, updateGhostAt, copySelected, copied]);
 
   return spacePressed;
 };
+
+export { useCanvasView } from './hooks/useCanvasView';

--- a/apps/web/src/components/editor/hooks/__tests__/useCanvasView.test.ts
+++ b/apps/web/src/components/editor/hooks/__tests__/useCanvasView.test.ts
@@ -1,0 +1,70 @@
+import { act, renderHook } from '@testing-library/react';
+import { useCanvasView } from '../useCanvasView';
+
+describe('useCanvasView', () => {
+  const defaultOptions = {
+    roomSize: { W: 10000, H: 8000 },
+    containerSize: { w: 800, h: 600 },
+    pxPerMm: 0.1,
+    padding: 20,
+  };
+
+  it('calculates fit within expected range', () => {
+    const { result } = renderHook(() => useCanvasView(defaultOptions));
+
+    expect(result.current.fit).toBeGreaterThan(0);
+    expect(result.current.fit).toBeLessThanOrEqual(1);
+  });
+
+  it('updates zoom at center', () => {
+    const { result } = renderHook(() => useCanvasView(defaultOptions));
+
+    act(() => {
+      result.current.zoomAtCenter(2);
+    });
+
+    expect(result.current.view.zoom).toBeCloseTo(2, 5);
+  });
+
+  it('resets view to defaults', () => {
+    const { result } = renderHook(() => useCanvasView(defaultOptions));
+
+    act(() => {
+      result.current.zoomAtCenter(2);
+      result.current.setPan(100, 50);
+    });
+
+    act(() => {
+      result.current.resetView();
+    });
+
+    expect(result.current.view).toEqual({ zoom: 1, panX: 0, panY: 0 });
+  });
+
+  it('clamps zoom to min and max', () => {
+    const { result } = renderHook(() => useCanvasView(defaultOptions));
+
+    act(() => {
+      result.current.zoomAtCenter(100);
+    });
+
+    expect(result.current.view.zoom).toBeLessThanOrEqual(10);
+
+    act(() => {
+      result.current.zoomAtCenter(0.001);
+    });
+
+    expect(result.current.view.zoom).toBeGreaterThanOrEqual(0.2);
+  });
+
+  it('adjusts pan when zooming at point', () => {
+    const { result } = renderHook(() => useCanvasView(defaultOptions));
+    const initialPan = result.current.view.panX;
+
+    act(() => {
+      result.current.zoomAtPoint(400, 300, 1.5);
+    });
+
+    expect(result.current.view.panX).not.toBe(initialPan);
+  });
+});

--- a/apps/web/src/components/editor/hooks/useCanvasView.ts
+++ b/apps/web/src/components/editor/hooks/useCanvasView.ts
@@ -1,0 +1,116 @@
+import { useCallback, useMemo, useState } from 'react';
+import { clamp } from '@planner/geometry';
+
+export interface CanvasView {
+  zoom: number;
+  panX: number;
+  panY: number;
+}
+
+export interface UseCanvasViewOptions {
+  roomSize: { W: number; H: number };
+  containerSize: { w: number; h: number };
+  pxPerMm: number;
+  padding: number;
+}
+
+export interface ZoomAtCenterOptions {
+  width?: number;
+  height?: number;
+}
+
+const MIN_ZOOM = 0.2;
+const MAX_ZOOM = 10;
+
+const clampZoom = (value: number) => clamp(value, MIN_ZOOM, MAX_ZOOM);
+
+export function useCanvasView({
+  roomSize,
+  containerSize,
+  pxPerMm,
+  padding,
+}: UseCanvasViewOptions) {
+  const [view, setView] = useState<CanvasView>({ zoom: 1, panX: 0, panY: 0 });
+
+  const fit = useMemo(() => {
+    const roomPxW = roomSize.W * pxPerMm;
+    const roomPxH = roomSize.H * pxPerMm;
+    const paddedW = roomPxW + padding * 2;
+    const paddedH = roomPxH + padding * 2;
+
+    if (!paddedW || !paddedH || !containerSize.w || !containerSize.h) {
+      return 1;
+    }
+
+    const scale = Math.min(containerSize.w / paddedW, containerSize.h / paddedH) || 1;
+    return Math.max(1e-6, Math.floor(scale * 1000) / 1000);
+  }, [containerSize.h, containerSize.w, padding, pxPerMm, roomSize.H, roomSize.W]);
+
+  const mm2px = pxPerMm * fit * view.zoom;
+
+  const zoomAtPoint = useCallback(
+    (sx: number, sy: number, factor: number) => {
+      setView((prev) => {
+        const nextZoom = clampZoom(prev.zoom * factor);
+        if (nextZoom === prev.zoom) return prev;
+
+        const baseX = padding;
+        const baseY = padding;
+
+        const oldMm2px = pxPerMm * fit * prev.zoom;
+        const newMm2px = pxPerMm * fit * nextZoom;
+
+        const newPanX =
+          sx -
+          baseX -
+          ((sx - baseX - prev.panX) / oldMm2px) * newMm2px;
+        const newPanY =
+          sy -
+          baseY -
+          ((sy - baseY - prev.panY) / oldMm2px) * newMm2px;
+
+        return {
+          zoom: nextZoom,
+          panX: newPanX,
+          panY: newPanY,
+        };
+      });
+    },
+    [fit, padding, pxPerMm]
+  );
+
+  const zoomAtCenter = useCallback(
+    (factor: number, size?: ZoomAtCenterOptions) => {
+      const width = size?.width ?? containerSize.w;
+      const height = size?.height ?? containerSize.h;
+      const centerX = width / 2;
+      const centerY = height / 2;
+      zoomAtPoint(centerX, centerY, factor);
+    },
+    [containerSize.h, containerSize.w, zoomAtPoint]
+  );
+
+  const resetView = useCallback(() => {
+    setView({ zoom: 1, panX: 0, panY: 0 });
+  }, []);
+
+  const setPan = useCallback((panX: number, panY: number) => {
+    setView((prev) => {
+      if (prev.panX === panX && prev.panY === panY) {
+        return prev;
+      }
+      return { ...prev, panX, panY };
+    });
+  }, []);
+
+  return {
+    view,
+    setView,
+    fit,
+    mm2px,
+    zoomAtPoint,
+    zoomAtCenter,
+    resetView,
+    setPan,
+  };
+}


### PR DESCRIPTION
## Summary
- extract zoom, pan, and fit calculations into a dedicated `useCanvasView` hook
- refactor `EditorCanvas` to consume the new hook and updated hotkey handling
- add unit coverage for the canvas view hook behaviour

## Testing
- npm run build:packages
- CI=1 npm run build:web

------
https://chatgpt.com/codex/tasks/task_e_68e3641ba2dc832da412ea158b76a0ad