### PR TITLE
Automate Prolog solver integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ Thumbs.db
 .env.*.local
 .env.local
 !.env.example
+!apps/api/.env
 
 # Next.js
 .next/

--- a/apps/api/.env
+++ b/apps/api/.env
@@ -1,0 +1,4 @@
+PROLOG_PATH=swipl
+PROLOG_MODULES_PATH=../../prolog
+SOLVER_TIMEOUT=30
+SOLVER_TEMP_DIR=/tmp/planner-solver

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { appConfig } from './config/app.config';
 import { ExportModule } from './export/export.module';
+import { SolverModule } from './solver/solver.module';
 
 /**
  * Root NestJS application module.
@@ -13,6 +14,7 @@ import { ExportModule } from './export/export.module';
       load: [() => appConfig],
     }),
     ExportModule,
+    SolverModule,
   ],
 })
 export class AppModule {}

--- a/apps/api/src/solver/__tests__/solver.service.spec.ts
+++ b/apps/api/src/solver/__tests__/solver.service.spec.ts
@@ -1,0 +1,24 @@
+import { ConfigService } from '@nestjs/config';
+import type { Plan } from '@planner/shared';
+import { ExportService } from '../../export/export.service';
+import { SolverService } from '../solver.service';
+
+describe('SolverService', () => {
+  let service: SolverService;
+
+  beforeEach(() => {
+    service = new SolverService(new ConfigService(), new ExportService());
+  });
+
+  it('should return INVALID_PLAN error when task is missing', async () => {
+    const plan: Plan = {
+      room: { W: 1000, H: 1000 },
+      objects: [],
+    };
+
+    const result = await service.solvePlan(plan);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.code).toBe('INVALID_PLAN');
+  });
+});

--- a/apps/api/src/solver/dto/solution.dto.ts
+++ b/apps/api/src/solver/dto/solution.dto.ts
@@ -1,0 +1,49 @@
+/**
+ * Describes desk placement returned by solver.
+ */
+export interface DeskPlacementRectDto {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface DeskBaseSizeDto {
+  w: number;
+  h: number;
+}
+
+export interface DeskPlacementDto {
+  id: string;
+  type: string;
+  rect: DeskPlacementRectDto;
+  orientation?: number;
+  base_size?: DeskBaseSizeDto;
+}
+
+export interface SolverMetadataDto {
+  executionTime: number;
+  placedDesks: number;
+  requestedDesks: number;
+}
+
+export interface SolverErrorDto {
+  code: string;
+  message: string;
+  details?: Record<string, unknown> | undefined;
+}
+
+export interface SolverSolutionPayload {
+  grid?: number;
+  desks: DeskPlacementDto[];
+}
+
+/**
+ * Generic solver response payload.
+ */
+export interface SolutionDto {
+  success: boolean;
+  solution?: SolverSolutionPayload;
+  metadata?: SolverMetadataDto;
+  error?: SolverErrorDto;
+}

--- a/apps/api/src/solver/dto/solve-plan.dto.ts
+++ b/apps/api/src/solver/dto/solve-plan.dto.ts
@@ -1,0 +1,13 @@
+import { IsNumber, IsOptional, Max, Min } from 'class-validator';
+import { ExportPlanDto } from '../../export/dto/export-plan.dto';
+
+/**
+ * DTO used to validate payload for solver endpoint.
+ */
+export class SolvePlanDto extends ExportPlanDto {
+  @IsOptional()
+  @IsNumber()
+  @Min(5)
+  @Max(300)
+  timeout?: number;
+}

--- a/apps/api/src/solver/solver.controller.ts
+++ b/apps/api/src/solver/solver.controller.ts
@@ -1,0 +1,42 @@
+import { Body, Controller, Post, Res } from '@nestjs/common';
+import type { Response } from 'express';
+import type { Plan } from '@planner/shared';
+import { SolverService } from './solver.service';
+import { SolvePlanDto } from './dto/solve-plan.dto';
+import type { SolutionDto } from './dto/solution.dto';
+
+/**
+ * HTTP controller responsible for solver operations.
+ */
+@Controller('solver')
+export class SolverController {
+  constructor(private readonly solverService: SolverService) {}
+
+  @Post('solve')
+  async solve(@Body() body: SolvePlanDto, @Res({ passthrough: true }) res: Response): Promise<SolutionDto> {
+    const { timeout, ...planPayload } = body;
+    const plan = planPayload as unknown as Plan;
+    const result = await this.solverService.solvePlan(plan, { timeout });
+
+    res.status(this.resolveStatusCode(result));
+    return result;
+  }
+
+  private resolveStatusCode(result: SolutionDto): number {
+    if (result.success) {
+      return 200;
+    }
+
+    switch (result.error?.code) {
+      case 'INVALID_PLAN':
+        return 400;
+      case 'SOLVER_TIMEOUT':
+        return 408;
+      case 'PROLOG_NOT_FOUND':
+      case 'PROLOG_ERROR':
+        return 500;
+      default:
+        return 200;
+    }
+  }
+}

--- a/apps/api/src/solver/solver.module.ts
+++ b/apps/api/src/solver/solver.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { SolverController } from './solver.controller';
+import { SolverService } from './solver.service';
+import { ExportModule } from '../export/export.module';
+
+/**
+ * Module encapsulating solver REST API and business logic.
+ */
+@Module({
+  imports: [ConfigModule, ExportModule],
+  controllers: [SolverController],
+  providers: [SolverService],
+  exports: [SolverService],
+})
+export class SolverModule {}

--- a/apps/api/src/solver/solver.service.ts
+++ b/apps/api/src/solver/solver.service.ts
@@ -1,0 +1,444 @@
+import { BadRequestException, Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { ExportService } from '../export/export.service';
+import { toProlog } from '@planner/serializer';
+import type { Plan } from '@planner/shared';
+import type { ExportPlanDto } from '../export/dto/export-plan.dto';
+import {
+  DeskPlacementDto,
+  SolutionDto,
+  SolverErrorDto,
+  SolverSolutionPayload,
+} from './dto/solution.dto';
+import { spawn } from 'node:child_process';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  access,
+  constants as fsConstants,
+  copyFile,
+  mkdtemp,
+  mkdir,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+
+type NormalizedDesk = DeskPlacementDto;
+
+interface SolverOptions {
+  timeout?: number;
+}
+
+interface PrologRunResult {
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+}
+
+@Injectable()
+export class SolverService {
+  private readonly logger = new Logger(SolverService.name);
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly exportService: ExportService,
+  ) {}
+
+  /**
+   * Runs Prolog solver for provided plan and returns solution description.
+   */
+  async solvePlan(plan: Plan, options: SolverOptions = {}): Promise<SolutionDto> {
+    if (!plan.task) {
+      return {
+        success: false,
+        error: {
+          code: 'INVALID_PLAN',
+          message:
+            'В задаче должно быть указано количество рабочих мест и их размеры.',
+        },
+      };
+    }
+
+    const startedAt = Date.now();
+
+    let prologProgram: string;
+    try {
+      // Reuse export service validation to ensure geometry correctness
+      this.exportService.validatePlanStructure(plan as unknown as ExportPlanDto);
+      prologProgram = toProlog(plan);
+    } catch (error) {
+      if (error instanceof BadRequestException) {
+        return {
+          success: false,
+          error: {
+            code: 'INVALID_PLAN',
+            message: error.message,
+          },
+        };
+      }
+      this.logger.error('Failed to prepare plan for solver', error instanceof Error ? error.stack : undefined);
+      return {
+        success: false,
+        error: {
+          code: 'PROLOG_ERROR',
+          message: 'Не удалось подготовить план для решателя.',
+        },
+      };
+    }
+
+    const timeoutSeconds = this.resolveTimeout(options.timeout);
+    const prologPath = this.resolvePrologExecutable();
+
+    let workspace: string | undefined;
+    try {
+      workspace = await this.createWorkspace();
+      const planFile = path.join(workspace, 'plan.pl');
+      await writeFile(planFile, prologProgram, 'utf8');
+
+      const runResult = await this.runPrologSolver(workspace, prologPath, timeoutSeconds);
+      if (runResult.timedOut) {
+        this.logger.warn(`Solver timed out after ${timeoutSeconds}s`);
+        return {
+          success: false,
+          error: {
+            code: 'SOLVER_TIMEOUT',
+            message: `Решение превысило лимит в ${timeoutSeconds} секунд. Попробуйте упростить план или увеличить таймаут.`,
+          },
+          metadata: {
+            executionTime: Date.now() - startedAt,
+            placedDesks: 0,
+            requestedDesks: plan.task.count,
+          },
+        };
+      }
+
+      if (runResult.exitCode !== 0) {
+        this.logger.error(`Solver exited with code ${runResult.exitCode}: ${runResult.stderr}`);
+        return {
+          success: false,
+          error: {
+            code: 'PROLOG_ERROR',
+            message: 'Решатель завершился с ошибкой. Подробности смотрите в логах.',
+          },
+          metadata: {
+            executionTime: Date.now() - startedAt,
+            placedDesks: 0,
+            requestedDesks: plan.task.count,
+          },
+        };
+      }
+
+      const solutionPath = path.join(workspace, 'solution.json');
+      const solutionContent = await this.safeReadFile(solutionPath);
+      if (!solutionContent) {
+        this.logger.error('Solution file was not produced by solver');
+        return {
+          success: false,
+          error: {
+            code: 'PROLOG_ERROR',
+            message: 'Решатель не вернул результат. Попробуйте повторить попытку.',
+          },
+          metadata: {
+            executionTime: Date.now() - startedAt,
+            placedDesks: 0,
+            requestedDesks: plan.task.count,
+          },
+        };
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(solutionContent);
+      } catch (error) {
+        this.logger.error('Failed to parse solver output as JSON', error instanceof Error ? error.stack : undefined);
+        return {
+          success: false,
+          error: {
+            code: 'PROLOG_ERROR',
+            message: 'Не удалось разобрать ответ решателя.',
+          },
+          metadata: {
+            executionTime: Date.now() - startedAt,
+            placedDesks: 0,
+            requestedDesks: plan.task.count,
+          },
+        };
+      }
+
+      const normalized = this.normalizeSolution(parsed, plan.task.count);
+      if (!normalized.success) {
+        return {
+          success: false,
+          error: normalized.error,
+          metadata: {
+            executionTime: Date.now() - startedAt,
+            placedDesks: normalized.placed,
+            requestedDesks: plan.task.count,
+          },
+        };
+      }
+
+      this.logger.log(
+        `Solver completed in ${Date.now() - startedAt}ms. Placed ${normalized.solution.desks.length}/${plan.task.count} desks`,
+      );
+
+      return {
+        success: true,
+        solution: normalized.solution,
+        metadata: {
+          executionTime: Date.now() - startedAt,
+          placedDesks: normalized.solution.desks.length,
+          requestedDesks: plan.task.count,
+        },
+      };
+    } catch (error) {
+      if (this.isPrologNotFound(error)) {
+        return {
+          success: false,
+          error: {
+            code: 'PROLOG_NOT_FOUND',
+            message: 'Решатель Prolog не найден. Убедитесь, что SWI-Prolog установлен.',
+          },
+          metadata: {
+            executionTime: Date.now() - startedAt,
+            placedDesks: 0,
+            requestedDesks: plan.task.count,
+          },
+        };
+      }
+
+      this.logger.error('Solver execution failed', error instanceof Error ? error.stack : undefined);
+      return {
+        success: false,
+        error: {
+          code: 'PROLOG_ERROR',
+          message: 'Произошла непредвиденная ошибка при выполнении решателя.',
+        },
+        metadata: {
+          executionTime: Date.now() - startedAt,
+          placedDesks: 0,
+          requestedDesks: plan.task.count,
+        },
+      };
+    } finally {
+      if (workspace) {
+        await this.cleanupWorkspace(workspace);
+      }
+    }
+  }
+
+  private resolveTimeout(requestTimeout?: number): number {
+    const defaultTimeout = Number(this.configService.get('SOLVER_TIMEOUT')) || 30;
+    const timeout = requestTimeout ?? defaultTimeout;
+    return Math.min(Math.max(timeout, 5), 300);
+  }
+
+  private resolvePrologExecutable(): string {
+    return this.configService.get<string>('PROLOG_PATH') || 'swipl';
+  }
+
+  private async createWorkspace(): Promise<string> {
+    const configuredDir = this.configService.get<string>('SOLVER_TEMP_DIR');
+    const baseDir = configuredDir || path.join(os.tmpdir(), 'planner-solver');
+    await mkdir(baseDir, { recursive: true });
+    const workspace = await mkdtemp(path.join(baseDir, 'run-'));
+    await this.copyPrologModules(workspace);
+    return workspace;
+  }
+
+  private async cleanupWorkspace(workspace: string): Promise<void> {
+    try {
+      await rm(workspace, { recursive: true, force: true });
+    } catch (error) {
+      this.logger.warn(`Failed to cleanup workspace ${workspace}: ${(error as Error).message}`);
+    }
+  }
+
+  private async copyPrologModules(targetDir: string): Promise<void> {
+    const modulesPath = this.resolveModulesPath();
+    await access(modulesPath, fsConstants.R_OK);
+    const entries = await readdir(modulesPath, { withFileTypes: true });
+    await Promise.all(
+      entries
+        .filter((entry) => entry.isFile() && entry.name.endsWith('.pl'))
+        .map((entry) =>
+          copyFile(path.join(modulesPath, entry.name), path.join(targetDir, entry.name)),
+        ),
+    );
+  }
+
+  private resolveModulesPath(): string {
+    const configured = this.configService.get<string>('PROLOG_MODULES_PATH');
+    if (configured) {
+      return configured;
+    }
+
+    const candidates = [
+      path.resolve(process.cwd(), 'prolog'),
+      path.resolve(process.cwd(), '../prolog'),
+      path.resolve(__dirname, '../../../../prolog'),
+      path.resolve(__dirname, '../../../../../prolog'),
+    ];
+
+    for (const candidate of candidates) {
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+    }
+
+    return path.resolve(process.cwd(), 'prolog');
+  }
+
+  private async runPrologSolver(
+    workspace: string,
+    executable: string,
+    timeoutSeconds: number,
+  ): Promise<PrologRunResult> {
+    const goal = [
+      "load_files(['rects','zones','tiles','layout_spiral','orient_spiral','plan_loader_spiral','plan']),",
+      "plan_loader_spiral:load_plan('plan.pl'),",
+      'plan_loader_spiral:solve_plan_spiral_oriented(Rects, Oris, Grid),',
+      "plan_loader_spiral:solve_plan_spiral_oriented_to_file('solution.json', json),",
+      'halt.',
+    ].join(' ');
+
+    return new Promise<PrologRunResult>((resolve, reject) => {
+      const child = spawn(executable, ['-q', '-g', goal, '-t', 'halt(1)'], {
+        cwd: workspace,
+      });
+
+      let stdout = '';
+      let stderr = '';
+      let timedOut = false;
+
+      const timeout = setTimeout(() => {
+        timedOut = true;
+        child.kill('SIGKILL');
+      }, timeoutSeconds * 1000);
+
+      child.stdout?.on('data', (chunk: Buffer) => {
+        stdout += chunk.toString();
+      });
+
+      child.stderr?.on('data', (chunk: Buffer) => {
+        stderr += chunk.toString();
+      });
+
+      child.on('error', (error) => {
+        clearTimeout(timeout);
+        reject(error);
+      });
+
+      child.on('close', (code) => {
+        clearTimeout(timeout);
+        resolve({ exitCode: code, stdout, stderr, timedOut });
+      });
+    });
+  }
+
+  private async safeReadFile(filePath: string): Promise<string | null> {
+    try {
+      await access(filePath, fsConstants.R_OK);
+      return await readFile(filePath, 'utf8');
+    } catch {
+      return null;
+    }
+  }
+
+  private normalizeSolution(parsed: unknown, requested: number): {
+    success: boolean;
+    solution: SolverSolutionPayload;
+    error?: SolverErrorDto;
+    placed: number;
+  } {
+    if (typeof parsed !== 'object' || parsed === null) {
+      return {
+        success: false,
+        solution: { desks: [] },
+        error: {
+          code: 'PROLOG_ERROR',
+          message: 'Ответ решателя имеет неверный формат.',
+        },
+        placed: 0,
+      };
+    }
+
+    const payload = parsed as { grid?: unknown; desks?: unknown };
+    const desks = Array.isArray(payload.desks) ? payload.desks : [];
+
+    const normalizedDesks: NormalizedDesk[] = desks
+      .map((desk) => {
+        if (typeof desk !== 'object' || desk === null) {
+          return null;
+        }
+        const item = desk as Record<string, unknown>;
+        const rect = item.rect as Record<string, unknown> | undefined;
+        if (!rect) {
+          return null;
+        }
+        const x = Number(rect.x);
+        const y = Number(rect.y);
+        const w = Number(rect.w);
+        const h = Number(rect.h);
+        if ([x, y, w, h].some((value) => Number.isNaN(value))) {
+          return null;
+        }
+        const orientationRaw = Number(item.orientation);
+        const orientation = Number.isFinite(orientationRaw)
+          ? ((Math.round(orientationRaw) % 4) + 4) % 4
+          : undefined;
+        const baseSizeRaw = item.base_size as Record<string, unknown> | undefined;
+        const baseSize = baseSizeRaw
+          ? {
+              w: Number(baseSizeRaw.w) || w,
+              h: Number(baseSizeRaw.h) || h,
+            }
+          : undefined;
+        const id = typeof item.id === 'string' && item.id.length > 0 ? item.id : undefined;
+        const type = typeof item.type === 'string' ? item.type : 'desk';
+        const normalized: NormalizedDesk = {
+          id: id ?? `desk-${Math.random().toString(36).slice(2, 8)}`,
+          type,
+          rect: { x, y, w, h },
+          orientation,
+          base_size: baseSize,
+        };
+        return normalized;
+      })
+      .filter((desk): desk is NormalizedDesk => Boolean(desk));
+
+    if (normalizedDesks.length === 0 || normalizedDesks.length < requested) {
+      return {
+        success: false,
+        solution: { desks: normalizedDesks },
+        error: {
+          code: 'NO_SOLUTION_FOUND',
+          message:
+            'Не удалось разместить все рабочие места. Попробуйте изменить параметры задачи.',
+          details: {
+            requested,
+            placed: normalizedDesks.length,
+          },
+        },
+        placed: normalizedDesks.length,
+      };
+    }
+
+    return {
+      success: true,
+      solution: {
+        grid: typeof payload.grid === 'number' ? payload.grid : undefined,
+        desks: normalizedDesks,
+      },
+      placed: normalizedDesks.length,
+    };
+  }
+
+  private isPrologNotFound(error: unknown): boolean {
+    return Boolean((error as NodeJS.ErrnoException)?.code === 'ENOENT');
+  }
+}

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -14,3 +14,61 @@ html, body {
   /* отключаем рывки при скролле тачпадом/колесом */
   overscroll-behavior: none;
 }
+
+.solve-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  border-radius: 10px;
+  border: none;
+  background: #4f46e5;
+  color: #fff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.solve-button:hover {
+  background: #4338ca;
+}
+
+.solve-button[disabled] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.solve-button .spinner {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 2px solid rgba(255, 255, 255, 0.4);
+  border-top-color: #fff;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.solver-error-panel {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  background: #fef2f2;
+  border: 1px solid #fecaca;
+  color: #991b1b;
+  padding: 12px 14px;
+  border-radius: 10px;
+}
+
+.solver-error-panel button {
+  margin-left: auto;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 16px;
+  cursor: pointer;
+}

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -8,14 +8,26 @@ import { ObjectPalette } from '../src/components/ObjectPalette';
 import { usePlanStore } from '../src/store/planStore';
 import { runAllBasicRules } from '@planner/rules';
 import { toProlog } from '@planner/serializer';
+import type { SolutionDto } from '../src/types/solver';
 
 const EditorCanvas = dynamic(
   () => import('../src/components/EditorCanvas').then(m => m.EditorCanvas),
   { ssr: false }
 );
 
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3333';
+
 export default function Home() {
-  const { plan, setPlan, setIssues, issues } = usePlanStore();
+  const {
+    plan,
+    setPlan,
+    setIssues,
+    issues,
+    solving,
+    solverError,
+    setSolving,
+    setSolverError,
+  } = usePlanStore();
   const [tab, setTab] = React.useState<'room' | 'objects' | 'issues'>('objects'); // ⬅️ добавили 'room'
 
   const checkPlan = () => setIssues(runAllBasicRules(plan));
@@ -77,6 +89,101 @@ export default function Home() {
     input.click();
   };
 
+  const solvePlan = async () => {
+    if (!plan.task) {
+      alert('Сначала укажите количество и размер рабочих мест в разделе «Помещение».');
+      return;
+    }
+
+    if (plan.objects.some(o => o.type === 'workplace')) {
+      const replace = window.confirm('Заменить существующие рабочие места на решение решателя?');
+      if (!replace) {
+        return;
+      }
+    }
+
+    setSolving(true);
+    setSolverError(null);
+
+    try {
+      const response = await fetch(`${API_BASE_URL.replace(/\/$/, '')}/solver/solve`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(plan),
+      });
+
+      let result: SolutionDto | null = null;
+      try {
+        result = await response.json();
+      } catch (error) {
+        console.error('Failed to parse solver response', error);
+      }
+
+      if (!result) {
+        setSolverError('Не удалось прочитать ответ решателя. Попробуйте еще раз.');
+        return;
+      }
+
+      if (!response.ok && !result.success) {
+        setSolverError(result.error?.message ?? 'Решатель вернул ошибку.');
+        return;
+      }
+
+      if (!result.success) {
+        const details = result.error?.details && typeof result.error.details === 'object'
+          ? ` (подробнее: ${JSON.stringify(result.error.details)})`
+          : '';
+        setSolverError(`${result.error?.message ?? 'Решатель вернул ошибку.'}${details}`);
+        return;
+      }
+
+      const desks = result.solution?.desks ?? [];
+      const preserved = plan.objects.filter(o => o.type !== 'workplace');
+      const workspace = usePlanStore.getState();
+      const nextObjects = desks.map((desk) => {
+        const normalizedOrientation = typeof desk.orientation === 'number'
+          ? (((Math.round(desk.orientation) % 4) + 4) % 4) as 0 | 1 | 2 | 3
+          : undefined;
+        const identifier = desk.id && desk.id.length > 0
+          ? desk.id
+          : workspace.nextIdForType('workplace');
+        return {
+          id: identifier,
+          type: 'workplace' as const,
+          rect: {
+            X: desk.rect.x,
+            Y: desk.rect.y,
+            W: desk.rect.w,
+            H: desk.rect.h,
+          },
+          properties: [],
+          orientation: normalizedOrientation,
+        };
+      });
+
+      const updatedPlan = {
+        ...plan,
+        objects: [...preserved, ...nextObjects],
+        task: plan.task
+          ? { ...plan.task, count: result.metadata?.placedDesks ?? plan.task.count }
+          : plan.task,
+      };
+
+      setPlan(updatedPlan);
+      setTab('objects');
+
+      const placed = result.metadata?.placedDesks ?? desks.length;
+      const timeMs = result.metadata?.executionTime ?? 0;
+      const seconds = (timeMs / 1000).toFixed(1);
+      alert(`Успешно размещено ${placed} рабочих мест за ${seconds} сек.`);
+    } catch (error) {
+      console.error('Solver request failed', error);
+      setSolverError('Не удалось подключиться к решателю. Проверьте, что сервер запущен.');
+    } finally {
+      setSolving(false);
+    }
+  };
+
   return (
     <main style={{
       display: 'grid', gridTemplateColumns: '1fr 380px', gap: 16,
@@ -84,11 +191,46 @@ export default function Home() {
     }}>
       <section style={{ display: 'flex', flexDirection: 'column', gap: 8, minWidth: 0, minHeight: 0 }}>
         <div style={{ display: 'flex', flexDirection: 'column', gap: 8, flex: '0 0 auto' }}>
-          <div style={{ display: 'flex', gap: 8 }}>
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
             <button onClick={checkPlan}>Проверить план</button>
             <button onClick={exportPlan}>Экспорт в Prolog</button>
             <button onClick={importSolution}>Импорт решения</button>
+            <button
+              onClick={solvePlan}
+              disabled={solving || !plan.task}
+              className="solve-button"
+              title="Автоматически разместить рабочие места"
+            >
+              {solving ? (
+                <>
+                  <span className="spinner" aria-hidden="true" />
+                  <span>Решение в процессе...</span>
+                </>
+              ) : (
+                <>
+                  <span aria-hidden="true">🪄</span>
+                  <span>Решить планировку</span>
+                </>
+              )}
+            </button>
           </div>
+          {!plan.task && (
+            <div style={{ fontSize: 12, color: '#6b7280' }}>
+              Укажите количество и размер рабочих мест в разделе «Помещение», чтобы запустить решатель.
+            </div>
+          )}
+          {solverError && (
+            <div className="solver-error-panel" role="alert">
+              <span aria-hidden="true">⚠️</span>
+              <div style={{ flex: 1 }}>
+                <strong>Ошибка решения:</strong>
+                <p style={{ margin: '4px 0 0 0' }}>{solverError}</p>
+              </div>
+              <button onClick={() => setSolverError(null)} aria-label="Закрыть уведомление">
+                ×
+              </button>
+            </div>
+          )}
           <ObjectPalette /> {/* ⬅️ палитра типов */}
         </div>
         <div style={{ flex: 1, minHeight: 0 }}>

--- a/apps/web/src/store/planStore.ts
+++ b/apps/web/src/store/planStore.ts
@@ -21,10 +21,14 @@ type State = {
   plan: Plan;
   selectedId?: string;
   issues: Issue[];
+  solving: boolean;
+  solverError: string | null;
 
   setPlan: (p: Plan) => void;
   setSelected: (id?: string) => void;
   setIssues: (i: Issue[]) => void;
+  setSolving: (solving: boolean) => void;
+  setSolverError: (error: string | null) => void;
 
   updateObject: (id: string, patch: Partial<StaticObject['rect']>) => void;
   updateRoom: (patch: Partial<Size>) => void;
@@ -79,11 +83,15 @@ export const usePlanStore = create<State>((set, get) => ({
 
   selectedId: undefined,
   issues: [],
+  solving: false,
+  solverError: null,
   _idCounters: {},
 
   setPlan: (p) => set({ plan: p, _idCounters: initCounters(p.objects) }),
   setSelected: (id) => set({ selectedId: id }),
   setIssues: (i) => set({ issues: i }),
+  setSolving: (solving) => set({ solving }),
+  setSolverError: (error) => set({ solverError: error }),
 
   updateObject: (id, patch) => set(s => ({
     plan: { ...s.plan, objects: s.plan.objects.map(o => o.id === id ? { ...o, rect: { ...o.rect, ...patch } } : o) }

--- a/apps/web/src/types/solver.ts
+++ b/apps/web/src/types/solver.ts
@@ -1,0 +1,31 @@
+export interface DeskPlacement {
+  id: string;
+  type: string;
+  rect: { x: number; y: number; w: number; h: number };
+  orientation?: number;
+  base_size?: { w: number; h: number };
+}
+
+export interface SolverSolution {
+  grid?: number;
+  desks: DeskPlacement[];
+}
+
+export interface SolverMetadata {
+  executionTime: number;
+  placedDesks: number;
+  requestedDesks: number;
+}
+
+export interface SolverError {
+  code: string;
+  message: string;
+  details?: { [key: string]: unknown };
+}
+
+export interface SolutionDto {
+  success: boolean;
+  solution?: SolverSolution;
+  metadata?: SolverMetadata;
+  error?: SolverError;
+}


### PR DESCRIPTION
## Summary
- add a dedicated NestJS solver module with REST endpoint to execute the Prolog planner and normalize results
- handle solver workspace management, error reporting, and expose DTOs shared with the frontend
- extend the web editor with a "Solve" action, progress indicator, and error messaging that applies returned desks to the current plan

## Testing
- npm run test -w @planner/api -- --runTestsByPath src/solver/__tests__/solver.service.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e38b2720f4832d9836dbb7c7d69cea