### PR TITLE
Fix spiral layout metadata for connectivity validation

### DIFF
--- a/prolog/layout_spiral.pl
+++ b/prolog/layout_spiral.pl
@@ -121,6 +121,9 @@ attempt_one_offset(N, Wr,Hr, S, WallClear, Corner, Mode, Budget,
     length(RectsMM, K), K =:= N,
     length(Oris, N), maplist(=(0), Oris),
 
+    % Get aisle width for Meta (required by connectivity validation)
+    zones:get_policy(min_aisle_width_mm, Aisle),
+
     Meta = _{ grid_mm:S,
               cells:_{x:Cx,y:Cy},
               room:_{w:Wr,h:Hr},

--- a/prolog/orient_spiral.pl
+++ b/prolog/orient_spiral.pl
@@ -77,7 +77,8 @@ orient_tiles(Rects, Meta, Doors, Oris, Proof) :-
             ),
             Oris),
 
-    ( connectivity:validate_pass_connectivity(Rects, Oris, Meta, Doors, PassDiag) -> true
+    connectivity:validate_pass_connectivity(Rects, Oris, Meta, Doors, PassDiag),
+    ( PassDiag = success -> true
     ; format(user_error, '[orient] PASS connectivity failed: ~w~n', [PassDiag]),
       fail
     ),


### PR DESCRIPTION
## Summary
- include the aisle-width policy when constructing the spiral layout metadata so connectivity checks have complete inputs
- ensure pass connectivity diagnostics are available to both success and failure paths by restructuring the check in `orient_spiral`

## Testing
- `swipl -g "use_module(layout_spiral), halt"` *(fails: `swipl` not available in container)*


------
https://chatgpt.com/codex/tasks/task_e_68e3b5aad66c832da173c82163d546b9