### PR TITLE
Fix SWI Prolog parsing errors in solver modules

### DIFF
--- a/prolog/connectivity.pl
+++ b/prolog/connectivity.pl
@@ -37,6 +37,9 @@ accessible_neighbor(BlockedSet, Cx, Cy, X, Y) :-
     Y >= 0, Y < Cy,
     \+ ord_memberchk((X,Y), BlockedSet).
 
+is_unblocked_cell(BlockedSet, Cell) :-
+    \+ ord_memberchk(Cell, BlockedSet).
+
 /* ------------------------------------------------------------------
    Grid connectivity validation (Stage 2)
    ------------------------------------------------------------------ */
@@ -50,7 +53,7 @@ validate_grid_connectivity(RectsMM, Meta, Doors, Diagnostic) :-
     rects_to_cells_grid(S, X0,Y0, Cx,Cy, ObsMM, BlockedSet),
 
     all_grid_cells(Cx, Cy, AllCells),
-    include({BlockedSet}/[Cell]>>(\+ ord_memberchk(Cell, BlockedSet)),
+    include({BlockedSet}/[Cell]>>is_unblocked_cell(BlockedSet, Cell),
             AllCells, FreeCells),
 
     list_to_ord_set(FreeCells, FreeSet),

--- a/prolog/layout_spiral.pl
+++ b/prolog/layout_spiral.pl
@@ -77,7 +77,7 @@ attempt_one_offset(N, Wr,Hr, S, WallClear, Corner, Mode, Budget,
     map_corner(Cx,Cy, Corner, CellsBase, CellsCornered),
 
     % Filter to free cells
-    include({BlockedSet}/[XY]>>(\+ ord_memberchk(XY, BlockedSet)),
+    include({BlockedSet}/[XY]>>is_free_cell(BlockedSet, XY),
         CellsCornered, FreeCells0),
     connectivity:filter_isolated_cells(BlockedSet, Cx, Cy, FreeCells0, FreeCells),
     length(FreeCells0, FreeCount0),
@@ -308,6 +308,9 @@ rects_to_cells_grid(S, X0,Y0, Cx,Cy, RectsMM, Blocked) :-
       ),
       Raw),
     sort(Raw, Blocked).
+
+is_free_cell(BlockedSet, XY) :-
+    \+ ord_memberchk(XY, BlockedSet).
 
 /* ------------------------------------------------------------------
    Spiral order over Cx×Cy grid. Base corner = top-left (tl).


### PR DESCRIPTION
## Summary
- adjust the spiral layout filtering to rely on a helper predicate instead of inline lambdas that triggered operator precedence issues in SWI Prolog
- reuse the same approach for connectivity filtering so the solver can enumerate unblocked cells without parse failures

## Testing
- not run (SWI Prolog is not installed in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e3bbb97458832d939aff3b2492fcda